### PR TITLE
Update maintainers: thebsdbox, +displague

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,7 @@ This file lists the maintainers of the overall Tinkerbell project. The responsib
 
 | Name | GitHub ID | Affiliation |
 | ---- | --------- | ----------- |
-| [Dan Finneran](mailto:daniel.finneran@gmail.com) | [thebsdbox](https://github.com/thebsdbox) | Equinix Metal |
-| [Marky Jackson](mailto:majackson@equinix.com) | [markyjackson-taulia](https://github.com/markyjackson-taulia) | Equinix Metal |
+| [Dan Finneran](mailto:daniel.finneran@gmail.com) | [thebsdbox](https://github.com/thebsdbox) | Loft Labs |
 | [Manuel Mendez](mailto:mmendez@equinix.com) | [mmlb](https://github.com/mmlb) | Equinix Metal |
+| [Marky Jackson](mailto:majackson@equinix.com) | [markyjackson-taulia](https://github.com/markyjackson-taulia) | Equinix Metal |
+| [Marques Johansson](mailto:mjohansson@equinix.com) | [displague](https://github.com/displague) | Equinix Metal |


### PR DESCRIPTION
Updating the MAINTAINERS.md to add myself and update Dan Finneran's affiliations.

I'm updating this in conjunction with https://github.com/cncf/foundation/edit/main/project-maintainers.csv changes.

(cc @jacobweinstock wrt https://github.com/tinkerbell/org/issues/10 )

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
