### PR TITLE
Add governance on fast tracking individuals to elevated roles

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -210,7 +210,7 @@ An individual to be fast tracked _should_ satisfy one or more of the following c
 - Has demonstratable knowledge in closely related projects that translates to the target project. For example, Kubernetes controller knowledge may translate between projects.
 - Meets all the requirements of roles with lesser responsibilities. For example, a fast track to Approver may occur if an individual meets all the Reviewer and Approver requirements in a short space of time (typically less than the timelines outlined for each role).
 
-An individual to be fast tracked _must_ have expressed support from a majority of existing maintainers.
+An individual to be fast tracked _must_ have expressed support from existing maintainers or admins from the Tinkerbell org.
 
 ___
 


### PR DESCRIPTION
Formalize fast tracking criteria in our governance model. 

The goal of fast tracking is to accommodate situations where it would be valuable to have individuals contributing at higher levels of responsibilities in shorter time frames. This compliments the fact that Tinkerbell is still relatively new and seeking knowledgeable individuals to contribute with increased responsibilities. 

This is a draft, feedback wanted.
